### PR TITLE
callable scenarios for actions: create, update, delete

### DIFF
--- a/src/actions/CreateAction.php
+++ b/src/actions/CreateAction.php
@@ -58,9 +58,8 @@ class CreateAction extends JsonApiAction
      * It must return a string representing the scenario to be assigned to the model before it is validated and saved.
      *  The signature of the callable should be as follows,
      *  ```php
-     *  function ($action, $model = null) {
+     *  function ($action, $model) {
      *      // $model is the requested model instance.
-     *      // If null, it means no specific model (e.g. CreateAction)
      *  }
      *  ```
      */
@@ -110,9 +109,10 @@ class CreateAction extends JsonApiAction
         }
 
         /* @var $model \yii\db\ActiveRecord */
-        $model = new $this->modelClass([
-            'scenario' => is_callable($this->scenario) ? call_user_func($this->scenario, $this->id) : $this->scenario,
-        ]);
+        $model = new $this->modelClass();
+        $model->setScenario(is_callable($this->scenario) ?
+            call_user_func($this->scenario, $this->id, $model) : $this->scenario
+        );
         RelationshipManager::validateRelationships($model, $this->getResourceRelationships(), $this->allowedRelations);
         $model->load($this->getResourceAttributes(), '');
         if ($this->isParentRestrictionRequired()) {

--- a/src/actions/CreateAction.php
+++ b/src/actions/CreateAction.php
@@ -40,15 +40,15 @@ class CreateAction extends JsonApiAction
      * Keep it empty for disable this ability
      * @see https://jsonapi.org/format/#crud-creating
      * @example
-     *  'allowedRelations' => [
-     *       'author' => ['idType' => 'integer'],
-     *       'photos' => ['idType' => 'integer', 'validator' => function($model, array $ids) {
-     *              $relatedModels = Relation::find()->where(['id' => $ids])->andWhere([additional conditions])->all();
-     *              if(count($relatedModels) < $ids) {
-     *                throw new HttpException(422, 'Invalid photos ids');
-     *            }
-     *        },
-     * ]
+     *     'allowedRelations' => [
+     *         'author' => ['idType' => 'integer'],
+     *         'photos' => ['idType' => 'integer', 'validator' => function($model, array $ids) {
+     *             $relatedModels = Relation::find()->where(['id' => $ids])->andWhere([additional conditions])->all();
+     *             if (count($relatedModels) < $ids) {
+     *                 throw new HttpException(422, 'Invalid photos ids');
+     *             }
+     *         },
+     *     ]
      */
 
     public $allowedRelations = [];

--- a/src/actions/CreateAction.php
+++ b/src/actions/CreateAction.php
@@ -45,9 +45,10 @@ class CreateAction extends JsonApiAction
      *              $relatedModels = Relation::find()->where(['id' => $ids])->andWhere([additional conditions])->all();
      *              if(count($relatedModels) < $ids) {
      *                throw new HttpException(422, 'Invalid photos ids');
-     *        }},
+     *            }
+     *        },
      * ]
-     **/
+     */
 
     public $allowedRelations = [];
 

--- a/src/actions/DeleteAction.php
+++ b/src/actions/DeleteAction.php
@@ -29,9 +29,8 @@ class DeleteAction extends JsonApiAction
      * It must return a string representing the scenario to be assigned to the model before it is validated and saved.
      *  The signature of the callable should be as follows,
      *  ```php
-     *  function ($action, $model = null) {
+     *  function ($action, $model) {
      *      // $model is the requested model instance.
-     *      // If null, it means no specific model (e.g. CreateAction)
      *  }
      *  ```
      */

--- a/src/actions/UpdateAction.php
+++ b/src/actions/UpdateAction.php
@@ -59,9 +59,8 @@ class UpdateAction extends JsonApiAction
      * It must return a string representing the scenario to be assigned to the model before it is validated and updated.
      *  The signature of the callable should be as follows,
      *  ```php
-     *  function ($action, $model = null) {
+     *  function ($action, $model) {
      *      // $model is the requested model instance.
-     *      // If null, it means no specific model (e.g. CreateAction)
      *  }
      *  ```
      */

--- a/src/actions/UpdateAction.php
+++ b/src/actions/UpdateAction.php
@@ -51,8 +51,19 @@ class UpdateAction extends JsonApiAction
      * ]
      **/
     public $allowedRelations = [];
+
     /**
-     * @var string the scenario to be assigned to the model before it is validated and updated.
+     * @var string|callable
+     * string - the scenario to be assigned to the model before it is validated and updated.
+     * callable - a PHP callable that will be executed during the action.
+     * It must return a string representing the scenario to be assigned to the model before it is validated and updated.
+     *  The signature of the callable should be as follows,
+     *  ```php
+     *  function ($action, $model = null) {
+     *      // $model is the requested model instance.
+     *      // If null, it means no specific model (e.g. CreateAction)
+     *  }
+     *  ```
      */
     public $scenario = Model::SCENARIO_DEFAULT;
     /**
@@ -88,7 +99,8 @@ class UpdateAction extends JsonApiAction
     {
         /* @var $model ActiveRecord */
         $model = $this->isParentRestrictionRequired() ? $this->findModelForParent($id) : $this->findModel($id);
-        $model->scenario = $this->scenario;
+        $model->scenario = is_callable($this->scenario) ?
+            call_user_func($this->scenario, $this->id, $model) : $this->scenario;
         if ($this->checkAccess) {
             call_user_func($this->checkAccess, $this->id, $model);
         }


### PR DESCRIPTION
callable scenarios for actions: create, update, delete

    /**
     * @var string|callable
     * string - the scenario to be assigned to the model before it is validated and saved.
     * callable - a PHP callable that will be executed during the action.
     * It must return a string representing the scenario to be assigned to the model before it is validated and saved.
     *  The signature of the callable should be as follows,
     *  ```php
     *  function ($action, $model) {
     *      // $model is the requested model instance.
     *  }
     *  ```
     */
    public $scenario = Model::SCENARIO_DEFAULT;