### PR TITLE
Prevent composite primary key parsing when $id is null

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
@@ -49,7 +49,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Build the stack
       run: docker-compose up -d

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"cebe/indent": "*",
 		"friendsofphp/php-cs-fixer": "~2.16",
 		"codeception/codeception": "5.1.*",
+		"behat/gherkin": "<4.11",
 		"codeception/module-yii2": "^1.1",
 		"codeception/module-rest": "^3.0",
 		"codeception/module-phpbrowser": "3.0.*",

--- a/src/actions/JsonApiAction.php
+++ b/src/actions/JsonApiAction.php
@@ -161,14 +161,17 @@ class JsonApiAction extends Action
         /* @var $modelClass ActiveRecordInterface */
         $modelClass = $this->modelClass;
         $keys = $modelClass::primaryKey();
-        if (count($keys) > 1) {
-            $values = explode(',', $id);
-            if (count($keys) === count($values)) {
-                $condition = array_combine($keys, $values);
+
+        if ($id !== null) {
+            if (count($keys) > 1) {
+                $values = explode(',', $id);
+                if (count($keys) === count($values)) {
+                    $condition = array_combine($keys, $values);
+                }
+            } else {
+                $idKey = reset($keys);
+                $condition = [$this->modelTable().'.'.$idKey => $id];
             }
-        } elseif ($id !== null) {
-            $idKey = reset($keys);
-            $condition = [$this->modelTable().'.'.$idKey => $id];
         }
 
         return $condition ?? [];


### PR DESCRIPTION
This PR fixes a bug in `findModelCondition()` when `$id` is `null` for models with composite primary keys.

Before this change, the method checked whether the model had a composite primary key before checking whether `$id` was `null`. As a result, the composite-key code path could call `explode(',', $id)` even when no ID was provided.

The fix is small and focused:
- check `$id !== null` first,
- only resolve primary key conditions when an identifier is actually present,
- keep the existing behavior unchanged for valid single and composite primary key values.

This prevents failures for the `null` ID case and makes the method behavior consistent.